### PR TITLE
Fix/second request

### DIFF
--- a/home_api_middleware.routing.yml
+++ b/home_api_middleware.routing.yml
@@ -1,5 +1,6 @@
 home_api_middleware.accommodation.inventory:
   path: '/api/accommodation/inventory'
+  methods: ['GET']
   defaults:
     _controller: '\Drupal\home_api_middleware\Controller\HomeApiMiddlewareInventoryController::handleRequest'
     _title: 'HOME API Inventory'
@@ -9,6 +10,7 @@ home_api_middleware.accommodation.inventory:
     _auth: ['key_auth', 'cookie']
 home_api_middleware.accommodation.providers:
   path: '/api/accommodation/providers'
+  methods: ['GET']
   defaults:
     _controller: '\Drupal\home_api_middleware\Controller\HomeApiMiddlewareProviderController::handleRequest'
     _title: 'HOME API Providers'
@@ -18,6 +20,7 @@ home_api_middleware.accommodation.providers:
     _auth: ['key_auth', 'cookie']
 home_api_middleware.accommodation.quality_labels:
   path: '/api/accommodation/quality-labels'
+  methods: ['GET']
   defaults:
     _controller: '\Drupal\home_api_middleware\Controller\HomeApiMiddlewareQualityLabelsController::handleRequest'
     _title: 'HOME API Quality labels'

--- a/src/Controller/AbstractHomeApiMiddlewareController.php
+++ b/src/Controller/AbstractHomeApiMiddlewareController.php
@@ -207,7 +207,7 @@ abstract class AbstractHomeApiMiddlewareController extends ControllerBase {
    */
   public function deleteTokenInTempStore() {
     $this->secondAttemptLeft = FALSE;
-    $this->tempStore->set('expired', TRUE);
+    $this->tempStore->delete('expire');
     $this->tempStore->delete('token');
   }
 

--- a/src/Controller/HomeApiMiddlewareInventoryController.php
+++ b/src/Controller/HomeApiMiddlewareInventoryController.php
@@ -12,29 +12,53 @@ use Symfony\Component\HttpFoundation\Request;
 class HomeApiMiddlewareInventoryController extends AbstractHomeApiMiddlewareController {
 
   /**
-   * Turns the incoming GET request to a POST request and forwards it.
+   * Transforms the incoming GET request to a POST request and forwards it.
    *
-   * @param Symfony\Component\HttpFoundation\Request $request
+   * @param \Symfony\Component\HttpFoundation\Request $request
    *   The original GET request.
    * @param string $path
    *   Subpath to send request to.
    *
-   * @return Symfony\Component\HttpFoundation\JsonResponse
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
    *   Response from HOME API.
    */
   public function handleRequest(Request $request, string $path = NULL): JsonResponse {
     $path = $this->settings->get('home_api')['inventory']['path'];
+
+    // If the request has already been transformed to a POST, it should not be transformed again.
+    if ($request->getMethod() == 'GET') {
+      $request = $this->transformRequest($request);
+    }
+
+    $response = parent::handleRequest($request, $path);
+
+    return $response;
+  }
+
+  /**
+   * Transforms the GET request into a POST request.
+   *
+   * Adds the city parameter to the new request if missing.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The original GET request.
+   *
+   * @return \Symfony\Component\HttpFoundation\Request
+   *   The transformed POST request.
+   */
+  public function transformRequest(Request $request): Request {
     $query = $request->query->all();
 
+    if (!array_key_exists('city', $query)) {
+      $query['city'] = '';
+    }
     $query = $this->processQueryParameters($query);
 
     $query = json_encode($query);
     $postRequest = new Request(content: $query);
     $postRequest->setMethod('POST');
 
-    $response = parent::handleRequest($postRequest, $path);
-
-    return $response;
+    return $postRequest;
   }
 
 }

--- a/src/HomeApiMiddlewareAuthenticationManager.php
+++ b/src/HomeApiMiddlewareAuthenticationManager.php
@@ -44,7 +44,7 @@ class HomeApiMiddlewareAuthenticationManager {
   /**
    * Drupal SharedTempStore created by Factory.
    *
-   * @var Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\SharedTempStore
    */
   protected $tempStore;
 


### PR DESCRIPTION
- Fixes the second request attempt in the edge case of the stored API token being invalid before it expires according to the value in shared temp store.
- Adds the city parameter if missing from the request to avoid status code 400 from the HOME API